### PR TITLE
Modified importResolver.js

### DIFF
--- a/lib/importResolver.js
+++ b/lib/importResolver.js
@@ -9,7 +9,7 @@ module.exports = function importResolver(importPath, basePath) {
     const pathComponents = importPath.split('/')
     const moduleName = pathComponents[0]
 
-    importPath = path.join('installed_contracts', moduleName, 'contracts', pathComponents.slice(1).join('/'))
+    importPath = path.join('node_modules', moduleName, pathComponents.slice(1).join('/'))
   }
 
   var resolvedPath = path.resolve(basePath && !isDependencyImport ? path.dirname(basePath) : process.cwd(), importPath);


### PR DESCRIPTION
 I've modified importResolver.js to look for npm contract dependencies in node_modules.

Otherwise, trying to `aragon-dev-cli publish 0x98fgfg8...` always led to the same error:

```
Error: Can't resolve import path "installed_contracts/@aragon/contracts/core/contracts/apps/App.sol
```

It seems importResolver.js was looking for external contract dependencies in a mysterious `installed_contracts` folder.

The change i've made make it look in the `node_modules` folder.

`aragon-dev-cli publish`publish process now seems to work fine. Hope it does not break anything else.

Thanks guys for your hard work.