### PR TITLE
Fix import resolver for scoped packages

### DIFF
--- a/lib/importResolver.js
+++ b/lib/importResolver.js
@@ -5,12 +5,7 @@ module.exports = function importResolver(importPath, basePath) {
   const pathChars = ['.', '/']
   const isDependencyImport = importPath && pathChars.indexOf(importPath[0]) == -1
 
-  if (isDependencyImport) {
-    const pathComponents = importPath.split('/')
-    const moduleName = pathComponents[0]
-
-    importPath = path.join('node_modules', moduleName, pathComponents.slice(1).join('/'))
-  }
+  if (isDependencyImport) path.join('node_modules', importPath)
 
   var resolvedPath = path.resolve(basePath && !isDependencyImport ? path.dirname(basePath) : process.cwd(), importPath);
 


### PR DESCRIPTION
Imports for scoped packages (e.g. `@aragon/core/contracts/...`) do not work because we're splitting the path for some reason.